### PR TITLE
✨ enable output read from parallel pipeline

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -20,7 +20,8 @@
 
 - [ ] Output reading in parallel thread pipeline.
 - [ ] Option to use module global ThreadPoolExecutor for functional operation.
-- [ ] Add data argument to functional pipeline
+- [ ] Add data argument to functional pipeline.
+- [x] Pipeline is None after `Pipeline`'s `cleanup` method is called.
 
 ### v0.1.2
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -18,10 +18,11 @@
 
 ### v0.1.1
 
-- [ ] Output reading in parallel thread pipeline.
+- [x] Output reading in parallel thread pipeline.
 - [ ] Option to use module global ThreadPoolExecutor for functional operation.
 - [ ] Add data argument to functional pipeline.
 - [x] Pipeline is None after `Pipeline`'s `cleanup` method is called.
+- [x] Serial pipeline data become None if it has been read once.
 
 ### v0.1.2
 

--- a/demo_pipeline.py
+++ b/demo_pipeline.py
@@ -141,6 +141,10 @@ def staged_serial():
     print("Stopping pipeline...")
     # Stop the loop and cleanup the pipeline
     pipeline.stop_loop()
+    # Let's try read the last result
+    latest = pipeline.get_results()
+    print("Last output:")
+    print(latest)
     pipeline.cleanup()
 
 
@@ -154,6 +158,10 @@ def staged_parallel():
     time.sleep(ON_TIME)
     print("Stopping pipeline...")
     pipeline.stop_loop()
+    # Let's try read the last result
+    latest = pipeline.get_results()
+    print("Last output:")
+    print(latest)
     pipeline.cleanup()
 
 

--- a/pystream/pipeline/parallel_pipeline.py
+++ b/pystream/pipeline/parallel_pipeline.py
@@ -13,7 +13,9 @@ class PipelineTerminated(Exception):
     pass
 
 
-def send_output(data: PipelineData, output_queue: Queue, block: bool = True) -> bool:
+def send_output(
+    data: PipelineData, output_queue: Queue, block: bool = True, replace: bool = False
+) -> bool:
     """Send output to a pipeline queue.
 
     Args:
@@ -21,14 +23,22 @@ def send_output(data: PipelineData, output_queue: Queue, block: bool = True) -> 
         output_queue (Queue): target queue
         block (bool, optional): Whether to wait until the queue
             is empty (wait for 10 seconds). Defaults to True.
+        replace (bool, optional): If true, when the queue is full,
+            replace the data currently in the queue with the given
+            new data. Defaults to False.
 
     Returns:
-        bool: _description_
+        bool: True if the data is successfully sent to the output queue
     """
     try:
         output_queue.put(data, block=block, timeout=10)
     except Full:
-        return False
+        if replace:
+            output_queue.get(block=False)
+            output_queue.put(data, block=False)
+            return True
+        else:
+            return False
     else:
         return True
 
@@ -54,6 +64,7 @@ class StageThread(Thread):
         links: StageLinks,
         name: str = "Stage",
         all_out: bool = True,
+        replace_output: bool = False,
     ) -> None:
         """Thread class for the stage
 
@@ -64,6 +75,9 @@ class StageThread(Thread):
             all_out (bool, optional): Whether to operate in all out mode,
                 i.e. all data that comes in must be send to output.
                 Defaults to True.
+            replace_output (bool, optional): If true, when the queue is full,
+                replace the data currently in the queue with the new data.
+                Defaults to False.
         """
         super().__init__(name=name, daemon=True)
         self.stage = stage
@@ -71,6 +85,7 @@ class StageThread(Thread):
         self.all_out = all_out
         self.output_enabled = True
         self.daemon = True
+        self.replace_output = replace_output
 
     def run(self) -> None:
         self.start_thread()
@@ -89,7 +104,12 @@ class StageThread(Thread):
                 continue
             data.data = self.stage(data.data)
             if self.output_enabled:
-                send_output(data, self.links.output_queue, block=self.all_out)
+                send_output(
+                    data,
+                    self.links.output_queue,
+                    block=self.all_out,
+                    replace=self.replace_output,
+                )
         self.process_cleanup()
 
     def process_cleanup(self):
@@ -112,7 +132,7 @@ class StagedThreadPipeline(PipelineBase):
         stages: List[StageCallable],
     ) -> None:
         """The class that will handle the staged pipeline
-        based on multi  threading.
+        based on multi threading.
 
         Args:
             stages (List[StageCallable]): The stages to be run
@@ -146,9 +166,8 @@ class StagedThreadPipeline(PipelineBase):
             self.stage_threads.append(StageThread(stage, links, f"PyStream-Stage"))
             self.stage_links.append(links)
             input_queue = output_queue
-        # The last stage will not send output to avoid blocking
-        # TODO: Handle output of pipeline without blocking
-        self.stage_threads[-1].output_enabled = False
+        # Replace output of the last stage to avoid blocking
+        self.stage_threads[-1].replace_output = True
         # The last stage's output is the input of the pipeline handler
         self.main_input_queue = input_queue
 

--- a/pystream/pipeline/pipeline.py
+++ b/pystream/pipeline/pipeline.py
@@ -121,10 +121,12 @@ class Pipeline:
         return self.pipeline.get_results().data
 
     def cleanup(self) -> None:
-        """Stop and cleanup the pipeline"""
+        """Stop and cleanup the pipeline. Do nothing if the pipeline has not
+        been initialized"""
         if self.pipeline is None:
-            raise PipelineUndefined("Pipeline has not been defined")
+            return
         self.pipeline.cleanup()
+        self.pipeline = None
 
     def __generate_pipeline_data(self, data: Any) -> PipelineData:
         """Handle whether to use input generator or given user data"""

--- a/pystream/pipeline/pipeline.py
+++ b/pystream/pipeline/pipeline.py
@@ -5,6 +5,7 @@ import time
 from typing import Any, Callable, List, Optional
 
 from pystream.data.pipeline_data import PipelineData
+from pystream.pipeline.pipeline_base import PipelineBase
 from pystream.stage.stage import StageCallable
 from .serial_pipeline import SerialPipeline
 from .parallel_pipeline import StagedThreadPipeline
@@ -26,7 +27,7 @@ class Pipeline:
 
     def __init__(self, input_generator: Optional[Callable[[], Any]] = None) -> None:
         self.stages_sequence: List[StageCallable] = []
-        self.pipeline = None
+        self.pipeline: Optional[PipelineBase] = None
         self.__input_generator: Callable[[], Any] = lambda: None
         if input_generator is not None:
             self.__input_generator = input_generator

--- a/pystream/pipeline/pipeline.py
+++ b/pystream/pipeline/pipeline.py
@@ -116,7 +116,17 @@ class Pipeline:
         self.__loop_thread.join()
 
     def get_results(self) -> Any:
-        """Get latest results from the pipeline"""
+        """Get latest results from the pipeline
+
+        Raises:
+            PipelineUndefined: raised if method `serialize` and
+                `parallelize` has not been invoked.
+
+        Returns:
+            Any: the last data from the pipeline. The same data cannot be
+                read twice. If the new data is not available, None is
+                returned.
+        """
         if self.pipeline is None:
             raise PipelineUndefined("Pipeline has not been defined")
         return self.pipeline.get_results().data

--- a/pystream/pipeline/pipeline_base.py
+++ b/pystream/pipeline/pipeline_base.py
@@ -37,7 +37,7 @@ class PipelineBase(ABC):
         """Get output from the last stage
 
         Returns:
-            Optional[PipelineData]: the obtained data
+            PipelineData: the obtained data
         """
         pass
 

--- a/pystream/pipeline/serial_pipeline.py
+++ b/pystream/pipeline/serial_pipeline.py
@@ -19,8 +19,8 @@ class SerialPipeline(PipelineBase):
         self.results = data
         return True
 
-    def get_results(self) -> Any:
-        return self.results.data
+    def get_results(self) -> PipelineData:
+        return self.results
 
     def cleanup(self) -> None:
         for stage in self.pipeline:

--- a/pystream/pipeline/serial_pipeline.py
+++ b/pystream/pipeline/serial_pipeline.py
@@ -20,7 +20,9 @@ class SerialPipeline(PipelineBase):
         return True
 
     def get_results(self) -> PipelineData:
-        return self.results
+        ret = self.results
+        self.results = PipelineData()
+        return ret
 
     def cleanup(self) -> None:
         for stage in self.pipeline:


### PR DESCRIPTION
- Output reading in parallel thread pipeline.
- Pipeline is None after `Pipeline`'s `cleanup` method is called.
- Serial pipeline data become None if it has been read once.